### PR TITLE
Updated peer and dev dependencies to allow chai 4.x and fetch-mock ^5.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This library depends on:
 
 ```
 "peerDependencies": {
-  "chai": "3.x",
-  "fetch-mock": "5.1.x"
+  "chai": "3.x || 4.x",
+  "fetch-mock": "^5.1.x"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "devDependencies": {
     "babel-preset-latest": "^6.16.0",
     "babel-register": "^6.16.3",
-    "chai": "3.x",
-    "fetch-mock": "5.1.x",
+    "chai": "3.x || 4.x",
+    "fetch-mock": "^5.1.x",
     "mocha": "^3.1.0"
   },
   "peerDependencies": {
-    "chai": "3.x",
-    "fetch-mock": "5.1.x"
+    "chai": "3.x || 4.x",
+    "fetch-mock": "^5.1.x"
   }
 }


### PR DESCRIPTION
Should fix npm warnings when using newer versions of peer dependencies.

    npm WARN chai-fetch-mock@1.0.0 requires a peer of chai@3.x but none was installed.
    npm WARN chai-fetch-mock@1.0.0 requires a peer of fetch-mock@5.1.x but none was installed.
